### PR TITLE
Upgrade parcel-builder to 1.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "deploy": "node deploy.js && parcel build view/*.html --out-dir dist --no-source-maps"
   },
   "devDependencies": {
-    "parcel-bundler": "1.11.0",
+    "parcel-bundler": "1.12.3",
     "parcel-plugin-json-url-loader": "0.1.2",
     "typescript": "^3.1.1",
     "tslint": "5.12.1"


### PR DESCRIPTION
I was getting an "Invalid Version: undefined" error while trying to build the project with "parcel-builder" in version 1.11.0. A bump to 1.12.3 seems to have fixed the issue for me.